### PR TITLE
[Test PR] Revert "Looks like fuzzing is failing permanently again"

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,27 @@
+name: CIFuzz
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'gitoxide'
+       language: rust
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'gitoxide'
+       language: rust
+       fuzz-seconds: 600
+   - name: Upload Crash
+     uses: actions/upload-artifact@v4
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: artifacts
+       path: ./out/artifacts


### PR DESCRIPTION
This fork-internal pull request, which is for testing only and should not be merged here (a separate upstream PR would be opened if called for), reverts commit 3d90ab05959f34803e26cffda6ac33993fb183fe to investigate why fuzzing seems to be working when I trigger it via `workflow_dispatch` yet repeatedly failed when triggered with the `pull_request` trigger in #1536, per https://github.com/Byron/gitoxide/pull/1536#issuecomment-2306295972.