### PR TITLE
Install libstdc++6:amd64 in the container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           dpkg --add-architecture amd64  # For 64-bit Node.js, for actions.
           apt-get update
-          apt-get install --no-install-recommends -y build-essential ca-certificates cmake curl git jq libssl-dev nodejs:amd64 pkgconf
+          apt-get install --no-install-recommends -y build-essential ca-certificates cmake curl git jq libssl-dev libssl3:amd64 pkgconf
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           dpkg --add-architecture amd64  # For 64-bit Node.js, for actions.
           apt-get update
-          apt-get install --no-install-recommends -y build-essential ca-certificates cmake curl git jq libssl-dev libssl3:amd64 pkgconf
+          apt-get install --no-install-recommends -y build-essential ca-certificates cmake curl git jq libssl-dev pkgconf
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           dpkg --add-architecture amd64  # For 64-bit Node.js, for actions.
           apt-get update
-          apt-get install --no-install-recommends -y build-essential ca-certificates cmake curl git jq libssl-dev pkgconf
+          apt-get install --no-install-recommends -y build-essential ca-certificates cmake curl git jq libssl-dev libstdc++6:amd64 pkgconf
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
*This is a fork-internal PR to update a feature branch with a squash, so the original history can be indefinitely preserved by reference to this PR. See 54c3f79935b72988f1ee48abf5d6811ba83d7ba2 for context.*

Installing `nodejs:amd64` in a 32-bit container to work around https://github.com/actions/checkout/issues/334 works by causing 64-bit libraries the external mapped `node20` needs (even though `nodejs:amd64` in Debian is Node 18), as described in https://github.com/actions/checkout/issues/334#issuecomment-2435101135. But this installed more packages than are needed.

It turns out that, at least with this image, the only libraries the container is missing are the 32-bit libstdc++ and its dependencies. It is therefore sufficient to install the `libstdc++6:amd64` package. This makes that change, squashing a few investigatory steps that led to it.