### PR TITLE
[Test PR] See if fuzzing is working again 

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,46 @@
+name: CIFuzz
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+      - 'ci/**'
+      - 'etc/**'
+      - 'src/**'
+      - 'tests/**'
+      - 'cargo-*/**'
+      - 'gix*/**'
+      - '*.toml'
+      - Makefile
+  workflow_dispatch:
+
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none  # The fuzzing actions don't use our github.token at all.
+
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: gitoxide
+          language: rust
+
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: gitoxide
+          language: rust
+          fuzz-seconds: 600
+
+      - name: Upload Crash
+        uses: actions/upload-artifact@v4
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts


### PR DESCRIPTION
a.k.a. Revert "deactivate fuzzing as it's not building anymore for unrelated reasons"

Like #1, this is a fork-internal PR for testing fuzzing.

There, it was necessary to open a PR on the upstream repo, in order to test whether a change to the code here would help, since the job won't actually check out and use code from a PR whose base branch (target) is in a fork. But so far, here, I'm mainly testing whether the problem has gone away by itself due to a new nightly Rust toolchain, so it might not end up being necessary to open an investigatory PR upstream before knowing if things are likely to work.

This reverts commit a661a8a0ab94f956f9036dd41a87ed46a8282bfe.

By the way, the automated CodeQL review comments are due to another thing I'm testing out in this fork: experimental CodeQL scanning for GitHub Actions workflows. There are tradeoffs associated with pinning all actions at specific commit hashes, and I am unsure if that is really a better approach overall for GitoxideLabs/gitoxide. But that's what the comments are recommending. Those comments are conceptually unrelated to what I am trying to test here.