### PR TITLE
Produce clash on CI in GNU/Linux with case-folding ext4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        num: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -231,14 +232,13 @@ jobs:
           (cd -- "$TMPDIR"; verify)
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
       - name: More writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed reps
         run: |
-          # Add two more "9" digits to the upper bound of the label range.
-          sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\199\2/' \
+          # Prepend leading digits "24" to the upper bound of the label range.
+          sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\124\2/' \
             gix-worktree-state/tests/state/checkout.rs
       - name: Test writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,20 +185,18 @@ jobs:
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
+  # TODO(integration): Remove all or at least most test-ext4-casefold jobs prior to merging #2008.
   test-ext4-casefold:
     strategy:
       matrix:
         # `--test-threads` operand
         parallel-tests:
-          - 1  # Never seems to fail, which makes sense.
-          - 2
-          - 3  # Never seems to fail, which does NOT make sense.
-          - 4
-          - 5
-          - 6
-          - 7
+          - 1  # Never fails.
+          - 2  # Usually fails.
+          - 3  # Almost never fails, somehow!
+          - 4  # Usually fails.
         # Duplicate jobs
-        rep: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', O, P]
+        rep: [A, B, C, D, E, F, G]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
-  test-ext4-casefold:
+  test-linux-casefold:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -194,34 +194,32 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up casefold directory
+      - name: Set up casefold directories
         run: |
           set -ux
-          dd if=/dev/zero of=~/ext4-casefold.img bs=100M count=150
-          mkfs.ext4 -O casefold -- ~/ext4-casefold.img
-          mkdir -- ~/ext4-casefold
-          sudo mount -- ~/ext4-casefold.img ~/ext4-casefold
-          sudo chown -- "$USER" ~/ext4-casefold
-          mkdir -- ~/ext4-casefold/icase
-          chattr +F -- ~/ext4-casefold/icase
-      - name: Map workspace and TMPDIR
-        run: |
-          set -ux
-          mkdir -- ~/ext4-casefold/icase/{workspace,tmp}
-          sudo mount --rbind -- ~/ext4-casefold/icase/workspace .
-          printf 'TMPDIR=%s\n' ~/ext4-casefold/icase/tmp >> "$GITHUB_ENV"
-      - name: Verify case-folding
-        run: |
-          set -ux
-          shopt -s nullglob
-          verify() {
+
+          fold() (
+            cd -- "$1"
+
+            # Set up a case-folding tmpfs filesystem.
+            sudo mount -t tmpfs -o casefold tmpfs .
+            sudo chown -- "$USER" .
+            chattr +F .
+
+            # Test that case-folding really works.
             touch a A
             files=(?)
             test "${#files[@]}" -eq 1
             rm a
-          }
-          verify
-          (cd -- "$TMPDIR"; verify)
+          )
+
+          # Set up workspace.
+          fold .
+
+          # Set up TMPDIR.
+          mkdir -- ~/tmp
+          fold ~/tmp
+          printf 'TMPDIR=%s\n' ~/tmp >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -556,7 +554,7 @@ jobs:
       - test
       - test-journey
       - test-fast
-      - test-ext4-casefold
+      - test-linux-casefold
       - test-fixtures-windows
       - test-32bit
       - test-32bit-windows-size-doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Use case-folding workspace directory
+      - name: Set up casefold directory
         run: |
           set -ux
           dd if=/dev/zero of=~/ext4-casefold.img bs=100M count=150
@@ -199,15 +199,24 @@ jobs:
           sudo chown -- "$USER" ~/ext4-casefold
           mkdir -- ~/ext4-casefold/icase
           chattr +F -- ~/ext4-casefold/icase
-          sudo mount --rbind -- ~/ext4-casefold/icase .
+      - name: Map workspace and TMPDIR
+        run: |
+          set -ux
+          mkdir -- ~/ext4-casefold/icase/{workspace,tmp}
+          sudo mount --rbind -- ~/ext4-casefold/icase/workspace .
+          printf 'TMPDIR=%s\n' ~/ext4-casefold/icase/tmp >> "$GITHUB_ENV"
       - name: Verify case-folding
         run: |
           set -ux
           shopt -s nullglob
-          touch a A
-          files=(?)
-          test "${#files[@]}" -eq 1
-          rm a
+          verify() {
+            touch a A
+            files=(?)
+            test "${#files[@]}" -eq 1
+            rm a
+          }
+          verify
+          (cd -- "$TMPDIR"; verify)
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,11 +188,11 @@ jobs:
   test-ext4-casefold:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
-        num: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        os-suffix: ['22.04', '24.04', '22.04-arm', '24.04-arm']
+        rep: [A, B, C, D, E]
       fail-fast: false
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-${{ matrix.os-suffix }}
 
     steps:
       - name: Warn if we could use tmpfs mounted with `-o casefold` instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,15 @@ jobs:
           sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\19\2/' \
             gix-worktree-state/tests/state/checkout.rs
       - name: Test (nextest)
-        run: cargo nextest run --workspace --no-fail-fast --test-threads=2
+        run: cargo nextest run --workspace --no-fail-fast
+      - name: Retest writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
+        run: |
+          set -x
+          for i in {1..20}; do
+            cargo nextest run -p gix-worktree-state-tests \
+              writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed \
+              --no-fail-fast --test-threads=2
+          done
 
   test-fixtures-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,11 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
+      - name: More writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed reps
+        run: |
+          # Add another "9" digit to the upper bound of the label range.
+          sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\19\2/' \
+            gix-worktree-state/tests/state/checkout.rs
       - name: Test (nextest)
         run: cargo nextest run --workspace --no-fail-fast --test-threads=2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,17 +247,14 @@ jobs:
           tool: nextest
       - name: More writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed reps
         run: |
-          # Add another "9" digit to the upper bound of the label range.
-          sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\19\2/' \
+          # Add two more "9" digits to the upper bound of the label range.
+          sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\199\2/' \
             gix-worktree-state/tests/state/checkout.rs
       - name: Test writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
         run: |
-          set -x
-          for i in {1..20}; do
-            cargo nextest run -p gix-worktree-state-tests \
-              writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed \
-              --no-fail-fast --test-threads=2
-          done
+          cargo nextest run -p gix-worktree-state-tests \
+            writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed \
+            --status-level=fail --test-threads=2
 
   test-fixtures-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,9 +279,7 @@ jobs:
           # Add another "9" digit to the upper bound of the label range.
           sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\19\2/' \
             gix-worktree-state/tests/state/checkout.rs
-      - name: Test (nextest)
-        run: cargo nextest run --workspace --no-fail-fast
-      - name: Retest writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
+      - name: Test writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
         run: |
           set -x
           for i in {1..20}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,38 @@ jobs:
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
+  test-ext4-casefold:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Use case-folding workspace directory
+        run: |
+          set -ux
+          dd if=/dev/zero of=~/ext4-casefold.img bs=100M count=150
+          mkfs.ext4 -O casefold -- ~/ext4-casefold.img
+          mkdir -- ~/ext4-casefold
+          sudo mount -- ~/ext4-casefold.img ~/ext4-casefold
+          sudo chown -- "$USER" ~/ext4-casefold
+          mkdir -- ~/ext4-casefold/icase
+          chattr +F -- ~/ext4-casefold/icase
+          sudo mount --rbind -- ~/ext4-casefold/icase .
+      - name: Verify case-folding
+        run: |
+          set -ux
+          shopt -s nullglob
+          touch a A
+          files=(?)
+          test "${#files[@]}" -eq 1
+          rm a
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Test (nextest)
+        run: cargo nextest run --workspace --no-fail-fast
+
   test-fixtures-windows:
     runs-on: windows-latest
 
@@ -497,6 +529,7 @@ jobs:
       - test
       - test-journey
       - test-fast
+      - test-ext4-casefold
       - test-fixtures-windows
       - test-32bit
       - test-32bit-windows-size-doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,17 @@ jobs:
   test-ext4-casefold:
     strategy:
       matrix:
-        parallel-tests: [2, 3, 4]
-        rep: [A, B, C, D, E, F, G, H]
+        # `--test-threads` operand
+        parallel-tests:
+          - 1  # Never seems to fail, which makes sense.
+          - 2
+          - 3  # Never seems to fail, which does NOT make sense.
+          - 4
+          - 5
+          - 6
+          - 7
+        # Duplicate jobs
+        rep: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', O, P]
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,12 @@ jobs:
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
   test-ext4-casefold:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Set up casefold directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,28 +198,76 @@ jobs:
         run: |
           set -ux
 
-          fold() (
-            cd -- "$1"
+          # FIXME: Either split the cases into two separate steps in the job, or remove the first
+          # case and have the check gate a warning that tmpfs casefold is available and preferable.
+          case "$(cat </sys/fs/tmpfs/features/casefold || :)" in
+          supported)
+            echo 'Case-folding tmpfs is available and will be used.' >&2
+            fold() (
+              cd -- "$1"
 
-            # Set up a case-folding tmpfs filesystem.
-            sudo mount -t tmpfs -o casefold tmpfs .
-            sudo chown -- "$USER" .
-            chattr +F .
+              # Set up a case-folding tmpfs filesystem.
+              sudo mount -t tmpfs -o casefold tmpfs .
+              sudo chown -- "$USER" .
+              chattr +F .
+
+              # Test that case-folding really works.
+              touch a A
+              files=(?)
+              test "${#files[@]}" -eq 1
+              rm a
+            )
+
+            # Set up workspace.
+            fold .
+
+            # Set up TMPDIR.
+            mkdir -- ~/tmp
+            fold ~/tmp
+            printf 'TMPDIR=%s\n' ~/tmp >> "$GITHUB_ENV"
+
+            ;;
+          *)
+            echo 'Case-folding tmpfs is unavailable. tmpfs-backed ext4 will be used.' >&2
+
+            # Create mount points.
+            mkdir -- ~/mnt ~/mnt/tmpfs-nocasefold ~/mnt/ext4-casefold
+
+            # Set up a tmpfs filesystem.
+            sudo mount -t tmpfs tmpfs -- ~/mnt/tmpfs-nocasefold
+            sudo chown -- "$USER" ~/mnt/tmpfs-nocasefold
+
+            # Set up a casefold-enabled ext4 filesystem backed by the tmpfs filesystem.
+            dd if=/dev/zero of=~/mnt/tmpfs-nocasefold/ext4-casefold.img bs=100M count=60
+            mkfs.ext4 -O casefold -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img
+            sudo mount -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img ~/mnt/ext4-casefold
+            sudo chown -- "$USER" ~/mnt/ext4-casefold
+
+            # Create a case-folding directory with `workspace` and `tmp` subdirectories.
+            mkdir -- ~/mnt/ext4-casefold/icase
+            chattr +F -- ~/mnt/ext4-casefold/icase
+            mkdir -- ~/mnt/ext4-casefold/icase/{workspace,tmp}
+
+            # Map our workspace to the `workspace` subdirectory.
+            sudo mount --rbind -- ~/mnt/ext4-casefold/icase/workspace .
+            cd .  # Pick up the bind.
+
+            # Arrange for the `tmp` subdirectory to be used instead of `/tmp`.
+            export TMPDIR=~/mnt/ext4-casefold/icase/tmp
+            echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
 
             # Test that case-folding really works.
-            touch a A
-            files=(?)
-            test "${#files[@]}" -eq 1
-            rm a
-          )
+            verify() {
+              touch a A
+              files=(?)
+              test "${#files[@]}" -eq 1
+              rm a
+            }
+            verify
+            (cd -- "$TMPDIR"; verify)
 
-          # Set up workspace.
-          fold .
-
-          # Set up TMPDIR.
-          mkdir -- ~/tmp
-          fold ~/tmp
-          printf 'TMPDIR=%s\n' ~/tmp >> "$GITHUB_ENV"
+            ;;
+          esac
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           tool: nextest
       - name: Test (nextest)
-        run: cargo nextest run --workspace --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast --test-threads=2
 
   test-fixtures-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,80 +194,51 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up casefold directories
+      - name: Set up casefold directories (in tmpfs-backed ext4)
         run: |
           set -ux
 
-          # FIXME: Either split the cases into two separate steps in the job, or remove the first
-          # case and have the check gate a warning that tmpfs casefold is available and preferable.
           case "$(cat </sys/fs/tmpfs/features/casefold || :)" in
           supported)
-            echo 'Case-folding tmpfs is available and will be used.' >&2
-            fold() (
-              cd -- "$1"
-
-              # Set up a case-folding tmpfs filesystem.
-              sudo mount -t tmpfs -o casefold tmpfs .
-              sudo chown -- "$USER" .
-              chattr +F .
-
-              # Test that case-folding really works.
-              touch a A
-              files=(?)
-              test "${#files[@]}" -eq 1
-              rm a
-            )
-
-            # Set up workspace.
-            fold .
-
-            # Set up TMPDIR.
-            mkdir -- ~/tmp
-            fold ~/tmp
-            printf 'TMPDIR=%s\n' ~/tmp >> "$GITHUB_ENV"
-
-            ;;
-          *)
-            echo 'Case-folding tmpfs is unavailable. tmpfs-backed ext4 will be used.' >&2
-
-            # Create mount points.
-            mkdir -- ~/mnt ~/mnt/tmpfs-nocasefold ~/mnt/ext4-casefold
-
-            # Set up a tmpfs filesystem.
-            sudo mount -t tmpfs tmpfs -- ~/mnt/tmpfs-nocasefold
-            sudo chown -- "$USER" ~/mnt/tmpfs-nocasefold
-
-            # Set up a casefold-enabled ext4 filesystem backed by the tmpfs filesystem.
-            dd if=/dev/zero of=~/mnt/tmpfs-nocasefold/ext4-casefold.img bs=100M count=60
-            mkfs.ext4 -O casefold -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img
-            sudo mount -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img ~/mnt/ext4-casefold
-            sudo chown -- "$USER" ~/mnt/ext4-casefold
-
-            # Create a case-folding directory with `workspace` and `tmp` subdirectories.
-            mkdir -- ~/mnt/ext4-casefold/icase
-            chattr +F -- ~/mnt/ext4-casefold/icase
-            mkdir -- ~/mnt/ext4-casefold/icase/{workspace,tmp}
-
-            # Map our workspace to the `workspace` subdirectory.
-            sudo mount --rbind -- ~/mnt/ext4-casefold/icase/workspace .
-            cd .  # Pick up the bind.
-
-            # Arrange for the `tmp` subdirectory to be used instead of `/tmp`.
-            export TMPDIR=~/mnt/ext4-casefold/icase/tmp
-            echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
-
-            # Test that case-folding really works.
-            verify() {
-              touch a A
-              files=(?)
-              test "${#files[@]}" -eq 1
-              rm a
-            }
-            verify
-            (cd -- "$TMPDIR"; verify)
-
+            echo '::warning:: The runner system supports case-folding tmpfs, which is preferable.'
             ;;
           esac
+
+          # Create mount points.
+          mkdir -- ~/mnt ~/mnt/tmpfs-nocasefold ~/mnt/ext4-casefold
+
+          # Set up a tmpfs filesystem.
+          sudo mount -t tmpfs tmpfs -- ~/mnt/tmpfs-nocasefold
+          sudo chown -- "$USER" ~/mnt/tmpfs-nocasefold
+
+          # Set up a casefold-enabled ext4 filesystem backed by the tmpfs filesystem.
+          dd if=/dev/zero of=~/mnt/tmpfs-nocasefold/ext4-casefold.img bs=100M count=60
+          mkfs.ext4 -O casefold -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img
+          sudo mount -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img ~/mnt/ext4-casefold
+          sudo chown -- "$USER" ~/mnt/ext4-casefold
+
+          # Create a case-folding directory with `workspace` and `tmp` subdirectories.
+          mkdir -- ~/mnt/ext4-casefold/icase
+          chattr +F -- ~/mnt/ext4-casefold/icase
+          mkdir -- ~/mnt/ext4-casefold/icase/{workspace,tmp}
+
+          # Map our workspace to the `workspace` subdirectory.
+          sudo mount --rbind -- ~/mnt/ext4-casefold/icase/workspace .
+          cd .  # Pick up the bind.
+
+          # Arrange for the `tmp` subdirectory to be used instead of `/tmp`.
+          export TMPDIR=~/mnt/ext4-casefold/icase/tmp
+          echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
+
+          # Test that case-folding really works.
+          verify() {
+            touch a A
+            files=(?)
+            test "${#files[@]}" -eq 1
+            rm a
+          }
+          verify
+          (cd -- "$TMPDIR"; verify)
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,11 +188,11 @@ jobs:
   test-ext4-casefold:
     strategy:
       matrix:
-        os-suffix: ['22.04', '24.04', '22.04-arm', '24.04-arm']
-        rep: [A, B, C, D, E]
+        parallel-tests: [2, 3, 4]
+        rep: [A, B, C, D, E, F, G, H]
       fail-fast: false
 
-    runs-on: ubuntu-${{ matrix.os-suffix }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Warn if we could use tmpfs mounted with `-o casefold` instead
@@ -244,7 +244,7 @@ jobs:
         run: |
           cargo nextest run -p gix-worktree-state-tests \
             writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed \
-            --status-level=fail --test-threads=2
+            --status-level=fail --test-threads=${{ matrix.parallel-tests }}
 
   test-fixtures-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
-  test-linux-casefold:
+  test-ext4-casefold:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -194,43 +194,33 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up casefold directories (in tmpfs-backed ext4)
+      - name: Warn if we could use tmpfs mounted with `-o casefold` instead
         run: |
-          set -ux
-
           case "$(cat </sys/fs/tmpfs/features/casefold || :)" in
           supported)
-            echo '::warning:: The runner system supports case-folding tmpfs, which is preferable.'
+            echo '::warning:: The runner OS supports case-folding tmpfs, which may be preferable.'
             ;;
           esac
-
-          # Create mount points.
-          mkdir -- ~/mnt ~/mnt/tmpfs-nocasefold ~/mnt/ext4-casefold
-
-          # Set up a tmpfs filesystem.
-          sudo mount -t tmpfs tmpfs -- ~/mnt/tmpfs-nocasefold
-          sudo chown -- "$USER" ~/mnt/tmpfs-nocasefold
-
-          # Set up a casefold-enabled ext4 filesystem backed by the tmpfs filesystem.
-          dd if=/dev/zero of=~/mnt/tmpfs-nocasefold/ext4-casefold.img bs=100M count=60
-          mkfs.ext4 -O casefold -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img
-          sudo mount -- ~/mnt/tmpfs-nocasefold/ext4-casefold.img ~/mnt/ext4-casefold
-          sudo chown -- "$USER" ~/mnt/ext4-casefold
-
-          # Create a case-folding directory with `workspace` and `tmp` subdirectories.
-          mkdir -- ~/mnt/ext4-casefold/icase
-          chattr +F -- ~/mnt/ext4-casefold/icase
-          mkdir -- ~/mnt/ext4-casefold/icase/{workspace,tmp}
-
-          # Map our workspace to the `workspace` subdirectory.
-          sudo mount --rbind -- ~/mnt/ext4-casefold/icase/workspace .
-          cd .  # Pick up the bind.
-
-          # Arrange for the `tmp` subdirectory to be used instead of `/tmp`.
-          export TMPDIR=~/mnt/ext4-casefold/icase/tmp
-          echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
-
-          # Test that case-folding really works.
+      - name: Set up casefold directory
+        run: |
+          set -ux
+          dd if=/dev/zero of=~/ext4-casefold.img bs=100M count=150
+          mkfs.ext4 -O casefold -- ~/ext4-casefold.img
+          mkdir -- ~/ext4-casefold
+          sudo mount -- ~/ext4-casefold.img ~/ext4-casefold
+          sudo chown -- "$USER" ~/ext4-casefold
+          mkdir -- ~/ext4-casefold/icase
+          chattr +F -- ~/ext4-casefold/icase
+      - name: Arrange to map workspace and TMPDIR in all subsequent steps
+        run: |
+          set -ux
+          mkdir -- ~/ext4-casefold/icase/{workspace,tmp}
+          sudo mount --rbind -- ~/ext4-casefold/icase/workspace .
+          printf 'TMPDIR=%s\n' ~/ext4-casefold/icase/tmp >> "$GITHUB_ENV"
+      - name: Verify case folding in workspace and TMPDIR
+        run: |
+          set -ux
+          shopt -s nullglob
           verify() {
             touch a A
             files=(?)
@@ -568,7 +558,7 @@ jobs:
       - test
       - test-journey
       - test-fast
-      - test-linux-casefold
+      - test-ext4-casefold
       - test-fixtures-windows
       - test-32bit
       - test-32bit-windows-size-doc


### PR DESCRIPTION
This adds a `test-ext4-casefold` matrix job definition to `ci.yml`, which is intended probably to be temporary, to demonstrate for #2008 that #2006 affects GNU/Linux (in addition to macOS and Windows), when the GNU/Linux system is using an ext4 volume with a case-insensitive directory tree, i.e., where the ext4 filesystem is created with `-O casefold` and operations are performed in a directory within that filesystem where `chattr +F` has been used to enable case-folding path equivalence.

The bug is nondeterministic and challenging to produce on GNU/Linux, even when the case-folding precondition is satisfied (as all the `test-ext4-casefold` jobs achieve). It is much harder to produce on GNU/Linux than on macOS or Windows. Accordingly, the number of duplicate test cases is increased 25-fold from 1000 to 25000 in those tests, and multiple jobs are created, some of them equivalent.

As expected, the failures do not occur when the runner does not run tests in parallel, and they do occur most of the time when the runner runs tests in parallel with a maximum number of parallel tests set to 2 or to 4. However, unexpectedly, the failures almost never occur when the test are run in parallel with a maximum number of parallel tests set to 3. It is unclear to what extent, if any, this generalizes, but I have not observed these patterns when testing locally, including when modifying the local procedure to be more similar to the behavior here (such as by suppressing reporting of non-failing tests and suppressing the progress bar). In local testing, I am unable to produce failures on some GNU/Linux systems, but on those on which I am able to produce them, they are easier to produce with all values of the `--test-threads` operand, including 3.

Not all operating systems, versions, and kernel builds and options support case-folding on ext4. But support is fairly common on Linux-based systems, and the CI runners have no problem with that. In contrast, although case-folding tmpfs also exists on Linux, it is newer and not (yet) supported as widely, and the GitHub-hosted runners do not support case-folding tmpfs. It is possible to mount a tmpfs filesystem and create an ext4 image in it so that, in principle, fewer operations need to access the disk. That is one of the approaches that was tried, but it does not appear to make it any easier to surface these failures.

This squashes multiple commits. (Mistakes, and less illuminating experiments, have already been omitted; the commits being squashes here are those that are expected to be of possible interest, but whose details are almost but not quite important enough to justify the cumbersome effect of having them individually in the history.) The squashed commits' individual messages are shown below.

For full changes and CI results from each commit, see:
https://github.com/EliahKagan/gitoxide/pull/36