### PR TITLE
Use single-threaded checkout in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
             gix-worktree-state/tests/state/checkout.rs
       - name: Test writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
         run: |
-          cargo nextest run -p gix-worktree-state-tests \
+          cargo nextest run -p gix-worktree-state-tests --no-default-features \
             writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed \
             --status-level=fail --test-threads=${{ matrix.parallel-tests }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,11 +242,18 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
-      - name: More writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed reps
+      - name: Increase writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed reps
         run: |
           # Prepend leading digits "24" to the upper bound of the label range.
           sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\124\2/' \
             gix-worktree-state/tests/state/checkout.rs
+      - name: Modify the test code to use single-threaded checkout
+        run: |
+          # Replace the usual `thread_limit` argument with `Some(1)`.
+          sed -i 's/gix_features::parallel::num_threads(None).into()/Some(1)/' \
+            gix-worktree-state/tests/state/checkout.rs
+      - name: Display the changes made for this test
+        run: git diff
       - name: Test writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)
         run: |
           cargo nextest run -p gix-worktree-state-tests --no-default-features \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,11 +247,6 @@ jobs:
           # Prepend leading digits "24" to the upper bound of the label range.
           sed -Ei 's/^(#\[test_matrix\(0\.\.=)([[:digit:]]+\)])$/\124\2/' \
             gix-worktree-state/tests/state/checkout.rs
-      - name: Modify the test code to use single-threaded checkout
-        run: |
-          # Replace the usual `thread_limit` argument with `Some(1)`.
-          sed -i 's/gix_features::parallel::num_threads(None).into()/Some(1)/' \
-            gix-worktree-state/tests/state/checkout.rs
       - name: Display the changes made for this test
         run: git diff
       - name: Test writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed (nextest)

--- a/gix-worktree-state/tests/state/checkout.rs
+++ b/gix-worktree-state/tests/state/checkout.rs
@@ -689,10 +689,11 @@ fn probe_gitoxide_dir() -> crate::Result<gix_fs::Capabilities> {
 fn opts_from_probe() -> gix_worktree_state::checkout::Options {
     static CAPABILITIES: Lazy<gix_fs::Capabilities> = Lazy::new(|| probe_gitoxide_dir().unwrap());
 
+    // FIXME(integration): Restore multithreaded `thread_limit` prior to merging #2008.
     gix_worktree_state::checkout::Options {
         fs: *CAPABILITIES,
         destination_is_initially_empty: true,
-        thread_limit: gix_features::parallel::num_threads(None).into(),
+        thread_limit: Some(1), // gix_features::parallel::num_threads(None).into(),
         ..Default::default()
     }
 }


### PR DESCRIPTION
This change, which is intended to be temporary, sets `thread_limit: Some(1)` in the `opts_from_probe()` test helper function in the `checkout.rs` test module, so that tests including `writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed` will use single-threaded checkout. This applies no matter how the tests are run.

In addition, for the `test-ext4-casefold` CI jobs (but not others), this adds the `--no-default-features` option to the `cargo nextest` command, so that the `gix-features-parallel` feature defined in `gix-worktree-state/Cargo.toml`, which when enabled causes `gix-features/parallel` to be enabled for the tests, is not enabled.

The purpose of these changes it to examine if, when checkout operations are themselves performed without multithreading, there is any change to #2006.

This does not make the failures go away. They still occur on all systems on which they had occurred before. It is unclear if it makes any difference to the failures. It seems like they may be slightly less likely to occur on GNU/Linux, but experiments so far are insufficient to confirm this. Furthermore, even if there is an effect, it may be that the effect is more subtle (such as possibly shifting the number of parallel tests where failures peak, from 2 to some higher number).

The changes here should not be confused with the duplication of the test case, nor with the argument to `--test-threads`, which actually specifies the number of parallel test *processes*, since `cargo nextest` is being used.

This squashes a few commits trying some minor variations. The original messages are shown below. For full changes and CI results from each commit, see:
https://github.com/EliahKagan/gitoxide/pull/37