### PR TITLE
Add `gix-diff` WASM check, even though `gix-path` covers it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,9 +460,8 @@ jobs:
       - name: crates with 'wasm' feature
         run: |
           set -x
-          for crate in gix-diff gix-pack; do
-            cargo build -p "$crate" --features wasm --target "$TARGET"
-          done
+          cargo build -p gix-diff --no-default-features --features wasm --target "$TARGET"
+          cargo build -p gix-pack --features wasm --target "$TARGET"
       - name: gix-pack with all features (including wasm)
         run: cargo build -p gix-pack --all-features --target "$TARGET"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,6 @@ jobs:
     strategy:
       matrix:
         target: [ wasm32-unknown-unknown, wasm32-wasip1 ]
-      fail-fast: false
 
     env:
       TARGET: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
       - name: crates with 'wasm' feature
         run: |
           set -x
-          for crate in gix-pack; do
+          for crate in gix-diff gix-pack; do
             cargo build -p "$crate" --features wasm --target "$TARGET"
           done
       - name: gix-pack with all features (including wasm)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,7 @@ jobs:
     strategy:
       matrix:
         target: [ wasm32-unknown-unknown, wasm32-wasip1 ]
+      fail-fast: false
 
     env:
       TARGET: ${{ matrix.target }}

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -44,7 +44,7 @@ gix-traverse = { version = "^0.47.0", path = "../gix-traverse", optional = true 
 thiserror = "2.0.0"
 imara-diff = { version = "0.1.8", optional = true }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
-getrandom = { version = "0.2.8", optional = true, default-features = false }
+getrandom = { version = "0.2.8", optional = true, default-features = false, features = ["js"] }
 bstr = { version = "1.12.0", default-features = false }
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -44,7 +44,7 @@ gix-traverse = { version = "^0.47.0", path = "../gix-traverse", optional = true 
 thiserror = "2.0.0"
 imara-diff = { version = "0.1.8", optional = true }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
-getrandom = { version = "0.2.8", optional = true, default-features = false, features = ["js"] }
+getrandom = { version = "0.2.8", optional = true, default-features = false }
 bstr = { version = "1.12.0", default-features = false }
 
 document-features = { version = "0.2.0", optional = true }


### PR DESCRIPTION
The purpose of this fork-internal PR is to facilitate a squash while being able to link to details of a testing methodology and associated CI results, where including the individual steps as separate commits (or even describing each of them individually in the commit message) are nonetheless not really justified.

This relates to #2093 shall be merged as a squash commit into a feature branch, either for that PR or a successor PR.

---

As noted in #2092, the `wasm` jobs on CI do not test `gix-diff` directly. However, my prediction there that breakage would not be detected on CI was mistaken, because those jobs do test the `wasm` feature of `gix-pack`. The `gix-pack` crate depends on `gix-diff`, and its `wasm` feature enable the `gix-diff` one.

This nonetheless adds an explicit check for `gix-diff`. This `gix-diff` check does not attempt to build default features, since some fail on some WASM targets. But the preexisting `gix-pack` check does still build the default features of `gix-pack`, which are compatible with WASM targets.

The efficacy of these checks, as well as the need to pass `--no-default-features` for `gix-diff`, can be confirmed by examining CI results for various fragments of this change experimented on in EliahKagan#75. This also demonstrates that CI is capable of catching at least some breakages related to the `wasm` feature of `gix-diff`, and thus may be sufficient to support moving forward with #2092.