### PR TITLE
Refine `check-no-persist-credentials` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,8 +546,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
       - name: Check that working tree is initially clean
         run: |
           set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,31 @@ jobs:
           git status
           git diff --exit-code
 
+  # Check that all `actions/checkout` in CI jobs have `persist-credentials: false`.
+  check-no-persist-credentials:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: '.github/workflows'
+      - name: List workflows to be scanned
+        run: |
+          shopt -s extglob
+          printf '%s\n' .github/workflows/*.@(yaml|yml)
+      - name: Scan workflows
+        run: |
+          shopt -s extglob
+          yq '.jobs.*.steps[]
+            | select(.uses == "actions/checkout@*" and .with.["persist-credentials"]? != false)
+            | {"file": filename, "line": line, "name": (.name // .uses)}
+            | .file + ":" + (.line | tostring) + ": " + .name
+          ' .github/workflows/*.@(yaml|yml) >query-output.txt
+          cat query-output.txt
+      - name: Check for matches
+        run: test -z "$(<query-output.txt)"
+
   # Check that only jobs intended not to block PR auto-merge are omitted as
   # dependencies of the `tests-pass` job below, so that whenever a job is
   # added, a decision is made about whether it must pass for PRs to merge.
@@ -615,6 +640,7 @@ jobs:
       - lint
       - cargo-deny
       - check-packetline
+      - check-no-persist-credentials
       - check-blocking
 
     if: always()  # Always run even if dependencies fail.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Check that working tree is initially clean
         run: |
           set -x
@@ -610,7 +612,6 @@ jobs:
           echo "WORKFLOW_PATH=${relative_workflow_with_ref%@*}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
           sparse-checkout: ${{ env.WORKFLOW_PATH }}
       - name: Get all jobs
         run: yq '.jobs | keys.[]' -- "$WORKFLOW_PATH" | sort | tee all-jobs.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,6 +563,9 @@ jobs:
   check-no-persist-credentials:
     runs-on: ubuntu-latest
 
+    env:
+      GLOB: .github/workflows/*.@(yaml|yml)
+
     steps:
       - uses: actions/checkout@v5
         with:
@@ -571,7 +574,7 @@ jobs:
       - name: List workflows to be scanned
         run: |
           shopt -s extglob
-          printf '%s\n' .github/workflows/*.@(yaml|yml)
+          printf '%s\n' ${{ env.GLOB }}
       - name: Scan workflows
         run: |
           shopt -s extglob
@@ -579,10 +582,9 @@ jobs:
             | select(.uses == "actions/checkout@*" and .with.["persist-credentials"]? != false)
             | {"file": filename, "line": line, "name": (.name // .uses)}
             | .file + ":" + (.line | tostring) + ": " + .name
-          ' .github/workflows/*.@(yaml|yml) >query-output.txt
+          ' -- ${{ env.GLOB }} >query-output.txt
           cat query-output.txt
-      - name: Check for matches
-        run: test -z "$(<query-output.txt)"
+          test -z "$(<query-output.txt)"  # Report failure if we found anything.
 
   # Check that only jobs intended not to block PR auto-merge are omitted as
   # dependencies of the `tests-pass` job below, so that whenever a job is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,6 +612,7 @@ jobs:
           echo "WORKFLOW_PATH=${relative_workflow_with_ref%@*}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           sparse-checkout: ${{ env.WORKFLOW_PATH }}
       - name: Get all jobs
         run: yq '.jobs | keys.[]' -- "$WORKFLOW_PATH" | sort | tee all-jobs.txt

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: ''
+          persist-credentials: false
       - uses: Swatinem/rust-cache@v2
       - name: stress
         run: make stress

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          persist-credentials: ''
       - uses: Swatinem/rust-cache@v2
       - name: stress
         run: make stress


### PR DESCRIPTION
This also tests the job by manually trying out several ways it should fail to make sure it does.

The purpose of this fork-internal PR is to squash this refinement of `check-no-persist-credentials`, together with the commits that temporarily break and then unbreak things to test that check, into one commit while still preserving a record of the individual commits.