### PR TITLE
[Test PR] Check compatibility with latest Git for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Upgrade Git for Windows
+        if: startsWith(matrix.os, 'windows')
+        run: winget upgrade git --accept-source-agreements
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -343,6 +346,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Upgrade Git for Windows
+        run: winget upgrade git --accept-source-agreements
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,12 +272,44 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up WinGet
-        if: matrix.os == 'windows-11-arm'
-        run: Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
-      - name: Upgrade Git for Windows
+      - name: Upgrade Git for Windows to latest stable release
         if: startsWith(matrix.os, 'windows')
-        run: winget upgrade git --silent --accept-source-agreements --accept-package-agreements
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OS: ${{ matrix.os }}
+        run: |
+          $workingDir = '~/git-dl'
+          $repo = 'git-for-windows/git'
+          $pattern = ($Env:OS -eq 'windows-11-arm' ? 'Git-*-arm64.exe' : 'Git-*-64-bit.exe')
+          $log = 'setup-log.txt'
+          # Inno Setup args reference: https://jrsoftware.org/ishelp/index.php?topic=setupcmdline
+          $arguments = @(
+            '/VERYSILENT',
+            '/SUPPRESSMSGBOXES',
+            '/ALLUSERS',
+            "/LOG=$log",
+            '/NORESTART',
+            '/CLOSEAPPLICATIONS',
+            '/FORCECLOSEAPPLICATIONS'
+          )
+
+          Write-Output 'Version and build information BEFORE upgrade:'
+          Write-Output ''
+          git version --build-options
+          Write-Output ''
+
+          mkdir $workingDir | Out-Null
+          cd $workingDir
+          gh release download --repo $repo --pattern $pattern
+          $installer = Get-Item $pattern
+          Start-Process -FilePath $installer -ArgumentList $arguments -NoNewWindow -Wait
+
+          Get-Content -Path $log -Tail 50
+
+          Write-Output ''
+          Write-Output 'Version and build information AFTER upgrade:'
+          Write-Output ''
+          git version --build-options
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -349,11 +381,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up WinGet
-        if: matrix.os == 'windows-11-arm'
-        run: Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
-      - name: Upgrade Git for Windows
-        run: winget upgrade git --silent --accept-source-agreements --accept-package-agreements
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Upgrade Git for Windows to latest stable release
+      - &upgrade_git_for_windows
+        name: Upgrade Git for Windows to latest stable release
         if: startsWith(matrix.os, 'windows')
         env:
           GH_TOKEN: ${{ github.token }}
@@ -381,6 +382,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - *upgrade_git_for_windows
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Set up WinGet
+        if: matrix.os == 'windows-11-arm'
+        run: Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
       - name: Upgrade Git for Windows
         if: startsWith(matrix.os, 'windows')
         run: winget upgrade git --accept-source-agreements
@@ -346,6 +349,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Set up WinGet
+        if: matrix.os == 'windows-11-arm'
+        run: Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
       - name: Upgrade Git for Windows
         run: winget upgrade git --accept-source-agreements
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         run: Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
       - name: Upgrade Git for Windows
         if: startsWith(matrix.os, 'windows')
-        run: winget upgrade git --accept-source-agreements
+        run: winget upgrade git --silent --accept-source-agreements --accept-package-agreements
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -353,7 +353,7 @@ jobs:
         if: matrix.os == 'windows-11-arm'
         run: Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
       - name: Upgrade Git for Windows
-        run: winget upgrade git --accept-source-agreements
+        run: winget upgrade git --silent --accept-source-agreements --accept-package-agreements
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false


### PR DESCRIPTION
This relates to #2221.

There have been multiple incompatibilities before where we needed to change something, usually in the test suite itself, so this experiement checks ahead of time, so we're not rushed.

I first tried to do this with `winget` but it was not successful, nor am I sure it would always get the latest version once published even if it did work properly. So I went back to the approach that has been added and removed upstream multiple times before, but I put it into a single step and used a YAML anchor to duplicate that step across jobs. See commit messages for details, including what was attempted with `winget` and why a YAML anchor is preferable in this specific case to extracting to a composite action.

---

The changes in this fork-internal PR are not meant to be merged anywhere in their current form, because we shouldn't default to upgrading or otherwise changing the version of Git for Windows to something other than what a runner provides. Nor should we test both this and the runner version of Git for Windows in every `push` or `pull_request` event, since that would incur significant delays.

But something like this could be turned off by default and made to be able to be turned on by another `matrix` variable, and also a `workflow-dispatch` parameter could be added that could let this be triggered manually. Considerations for that:

- It may also make sense to allow the pattern to be customized, or otherwise to include other logic to allow other versions besides the latest to be selected--since occasionally it may be necessary to *downgrade* Git for Windows to check that a problem is triggered by a newer version of it (and maybe temporarily to work around such a problem, but hopefully not).
- More important is that, in practice, if we need to upgrade or downgrade Git for Windows, it is often only needed for either `test-fast` or `test-fixtures-windows` and not the other (at least based on how things have gone before), so it would be good to be able to easily turn it on for just one.