### PR TITLE
Preview upcoming `windows-2025-vs2026` and `macos-26` images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2025
+          - windows-2025-vs2026
           - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
@@ -259,9 +259,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2025-vs2026
           - windows-11-arm
-          - macos-latest
+          - macos-26
           - ubuntu-latest
           - ubuntu-24.04-arm
         include:
@@ -331,7 +331,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2025-vs2026
           - windows-11-arm
         include:
           - test-args: ""
@@ -450,7 +450,7 @@ jobs:
         run: cargo nextest run --workspace --no-fail-fast --exclude gix-error
 
   test-32bit-windows-size-doc:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     env:
       TARGET: i686-pc-windows-msvc

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-26') || 'ubuntu-latest' }}
     permissions:
       # required for all workflows
       security-events: write  # Required for uploading SARIF to view in the Security tab.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,18 +134,18 @@ jobs:
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-26-intel
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
           - target: x86_64-pc-windows-gnu
-            os: windows-latest
+            os: windows-2025-vs2026
             rust: stable-x86_64-gnu
           - target: i686-pc-windows-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
           - target: aarch64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
         # On linux we build with musl which causes trouble with open-ssl. For now, just build max-pure there.
         # It's a TODO. See https://github.com/GitoxideLabs/gitoxide/issues/1242.
         exclude:
@@ -280,7 +280,7 @@ jobs:
           cp -- {README.md,LICENSE-*,CHANGELOG.md} "$ARCHIVE/"
 
       - name: Build archive (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025-vs2026'
         run: |
           file -- "$TARGET_DIR/$PROFILE"/{ein,gix}.exe
           cp -- "$TARGET_DIR/$PROFILE"/{ein,gix}.exe "$ARCHIVE/"
@@ -290,7 +290,7 @@ jobs:
           echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> "$GITHUB_ENV"
 
       - name: Build archive (Unix)
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2025-vs2026'
         run: |
           file -- "$TARGET_DIR/$PROFILE"/{ein,gix}
           cp -- "$TARGET_DIR/$PROFILE"/{ein,gix} "$ARCHIVE/"
@@ -306,7 +306,7 @@ jobs:
 
   # Add a macOS universal binary archive for a feature using its built aarch64 and x86_64 assets.
   build-macos-universal2-release:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     needs: [ create-release, build-release ]
 
@@ -523,19 +523,19 @@ jobs:
         build: [ win-msvc, win-gnu, win32-msvc, win32-gnu ]
         include:
           - build: win-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
             rust: stable
             target: x86_64-pc-windows-msvc
           - build: win-gnu
-            os: windows-latest
+            os: windows-2025-vs2026
             rust: stable-x86_64-gnu
             target: x86_64-pc-windows-gnu
           - build: win32-msvc
-            os: windows-latest
+            os: windows-2025-vs2026
             rust: stable
             target: i686-pc-windows-msvc
           - build: win32-gnu
-            os: windows-latest
+            os: windows-2025-vs2026
             rust: stable
             target: i686-pc-windows-gnu
 


### PR DESCRIPTION
## Summary

Fork-internal experimental PR: retarget every affected `runs-on` value across `ci`, `codeql`, and `release` workflows to the freshest GA / preview runner labels available, exercising the new images ahead of the upcoming brownout.

GitHub is migrating three runner labels per the [May 14 2026 changelog post](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/):

- `windows-latest` and `windows-2025` get Visual Studio 2026 between **June 8-15, 2026**.
- `macos-latest` starts pointing to macOS 26 over a 30-day rollout beginning **June 15, 2026**.

This PR moves us to `windows-2025-vs2026` (preview) and `macos-26` (GA since Feb 2026) for those.

It also swaps `macos-15-intel` → `macos-26-intel` for the `x86_64-apple-darwin` release target. That label is not in the May 14 brownout post, but `macos-26-intel` became GA in the same Feb 26 2026 announcement as `macos-26`; doing the arm64 swap without the Intel swap is an asymmetry not worth keeping in a "preview the freshest images" branch. The two `matrix.os == 'windows-latest'` archive-packaging conditionals in `release.yml` are updated to compare against the renamed matrix value so Windows-vs-Unix archive selection keeps working. The `codeql` swift conditional is updated for completeness even though swift is not in the active language matrix.

## Labels left as-is (no fresher GA/preview exists)

- `ubuntu-latest` — already on the freshest GA image; no `ubuntu-26.04` runner label exists yet (Ubuntu 26.04 LTS is still in beta).
- `ubuntu-slim` — already the GA 1-vCPU variant.
- `ubuntu-24.04-arm` — no `ubuntu-26.04-arm` exists yet.
- `windows-11-arm` — only Windows-arm64 label GitHub offers.

## Scope and intent

- This PR is **fork-internal**: head and base both live in `EliahKagan/gitoxide`. It is not intended for upstream review and should not be cherry-picked or merged into `GitoxideLabs/gitoxide` as-is.
- The whole point is to surface incompatibilities with the new images on `ci`, `codeql`, `cifuzz`, and `zizmor` before the brownout reaches the unprefixed labels.
- `release.yml` is included in the diff for parity, but it only triggers on tag pushes. Exercising it in CI would require pushing a `v*-DO-NOT-USE` tag to this fork, which has not been requested in this session — so the release path is **not** validated by this PR.

## AI authorship disclosure

This change was authored end-to-end by Claude Opus 4.7 (1M context), Anthropic's coding agent, working on behalf of @EliahKagan. The commit carries a `Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer per the repository's [contributing guidelines on disclosing AI use](https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md). This PR description is also AI-generated.

## Test plan

- [ ] `ci` workflow (triggered via `pull_request: branches: [main]`)
  - [ ] `cargo check MSRV (windows-2025-vs2026)` succeeds
  - [ ] `test-fast (windows-2025-vs2026)` succeeds
  - [ ] `test-fast (macos-26)` succeeds
  - [ ] `test-fixtures-windows (windows-2025-vs2026)` succeeds
  - [ ] `test-32bit-windows-size-doc` succeeds
- [ ] `codeql` workflow runs (matrix is `actions` + `rust`; swift conditional is dormant)
- [ ] `zizmor` and `cifuzz` workflows complete (`ubuntu-latest` only; unaffected by the migration but should still pass)
- [ ] `release.yml` is **not** exercised here (would need a tag push, deliberately deferred). Notably, that includes the `macos-26-intel` swap, which can only be validated by a release-workflow run.

## Sources

- [GitHub Actions: Upcoming image migrations (May 14, 2026)](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/)
- [macos-26 is now generally available (Feb 26, 2026)](https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/)
- [1 vCPU Linux runner now generally available (Jan 22, 2026)](https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/)
- [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)